### PR TITLE
Fix failed techdoc generation caused by python 3.12, and more changes

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -10,6 +10,8 @@ runs:
   steps:
     - name: Setup Node.js
       uses: actions/setup-node@v3
+      with:
+        node-version: 18
 
     - name: Setup Python
       uses: actions/setup-python@v3

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -15,6 +15,8 @@ runs:
 
     - name: Setup Python
       uses: actions/setup-python@v3
+      with:
+        python-version: '3.11'
 
     - name: Setup Java
       uses: actions/setup-java@v3

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -14,7 +14,7 @@ runs:
         node-version: 18
 
     - name: Setup Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
 

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
 

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -1,10 +1,11 @@
 name: "Setup Techdocs Dependencies"
 description: "Installs dependencies for publishing techdocs"
 inputs:
-  mkdocs-techdocs-core-version:
-    description: "The name of the bucket to publish techdocs to."
+  pip-requirements-txt:
+    description: "Override the dependencies installed by pip"
     required: false
-    default: "1.0.2"
+    default: |
+      mkdocs-techdocs-core==1.0.2
 runs:
   using: "composite"
   steps:
@@ -42,4 +43,8 @@ runs:
 
     - name: Install mkdocs and mkdocs-techdocs-core plugin
       shell: bash
-      run: python -m pip install mkdocs-techdocs-core==${{ inputs.mkdocs-techdocs-core-version }}
+      run: |
+        mkdir -p tmp
+        echo "${{ inputs.pip-requirements-txt }}" > tmp/techdocs-requirements.txt
+        python -m pip install -r tmp/techdocs-requirements.txt
+        rm tmp/techdocs-requirements.txt

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Override the dependencies installed by pip"
     required: false
     default: |
-      mkdocs-techdocs-core==1.0.2
+      mkdocs-techdocs-core
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Meaningful changes:
- set node-version to 18
- set python version to 3.11
- remove default constraint on mkdocs-techdocs-core
- remove support for the `mkdocs-techdocs-core-version` input, replaced by the following
- support overriding `pip-requirements-txt` in an input to the setup action

Other changes:
- bump setup-node action to v4
- bump setup-python action to v4

The python constraint in this PR resolves the following issue which crops up during techdocs builds:

    File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/markdown/util.py", line 85, in <module>
        INSTALLED_EXTENSIONS = metadata.entry_points().get('markdown.extensions', ())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'EntryPoints' object has no attribute 'get'